### PR TITLE
Add support for streams / pipes

### DIFF
--- a/avstream.js
+++ b/avstream.js
@@ -1,0 +1,25 @@
+var util   = require('util'),
+    Stream = require('stream');
+
+function AvStream(options) {
+    // Allow use without new operator
+    if (!(this instanceof AvStream)) {
+        return new AvStream(options);
+    }
+
+    Stream.Duplex.call(this, options);
+}
+
+// AvStream inherits the Duplex stream prototype
+util.inherits(AvStream, Stream.Duplex);
+
+AvStream.prototype._read = function _read(n) {};
+
+AvStream.prototype._write = function _write(chunk, encoding, callback) {
+    // Data written to the stream should be emitted back as 'inputData'
+    this.emit('inputData', chunk);
+
+    callback();
+};
+
+module.exports = AvStream;


### PR DESCRIPTION
I love the simplicity of your avconv library, but I was sorely lacking support for pipe:0 input and pipe:1 output.

This commit adds that.

All the informational data is now emitted as a 'message' event,
while the converted data is now using the 'data' event.

The 'end' event has also been renamed to 'exit', because the 'end' event makes the stream unreadable.
