### PR TITLE
Extract more meta data from output

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+3.0.0 / 2015-04-22
+==================
+
+ * Rebuild meta data parsing (breaking):
+   - the `meta` event has been removed, metadata is now provided as third argument to the `exit` listener
+   - metadata format changed to a more generic per stream structure, [see readme](https://github.com/binarykitchen/avconv#metadata-object).
+
 2.0.0 / 2014-05-14
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "avconv",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "description": "Simply spawns an avconv process with any parameters and *streams* the result + conversion progress to you. Very small, fast, clean and does only this.",
     "main": "avconv.js",
     "author": "Michael Heuberger <michael.heuberger@binarykitchen.com>",
@@ -12,6 +12,10 @@
         {
             "name": "Jelle De Loecker",
             "email": "jelle@kipdola.be"
+        },
+        {
+            "name": "Jan Scheurer",
+            "email": "lj1102@googlemail.com"
         }
     ],
     "keywords": [

--- a/tests/basics.js
+++ b/tests/basics.js
@@ -180,25 +180,55 @@ module.exports = testCase({
                 previousProgress = progress;
             });
 
-            stream.on('meta', function(meta) {
-                t.strictEqual(meta.video.track,  '0.0',         'Video track number is correct');
-                t.strictEqual(meta.video.codec,  'h264 (Main)', 'Video codec is correct');
-                t.strictEqual(meta.video.format, 'yuv420p',     'Video format is correct');
-                t.strictEqual(meta.video.width,  320,           'Video width is correct');
-                t.strictEqual(meta.video.height, 240,           'Video height is correct');
-            });
-
             stream.on('error', function(data) {
                 errors += data;
             });
 
-            stream.once('exit', function(exitCode, signal) {
+            stream.once('exit', function(exitCode, signal, meta) {
+                var videoStreamMeta, audioStreamMeta;
 
                 t.strictEqual(exitCode, 0,    'Video has been successfully generated');
                 t.strictEqual(errors,   '',   'No errors occured at all');
                 t.strictEqual(signal, null,   'Signal is null');
 
                 t.ok(datas.length > 0, 'There is data');
+                // Input meta data
+                t.strictEqual(meta.input.stream.length, 1, 'Input file streams correctly detected')
+                t.strictEqual(meta.input.stream[0].length, 2, 'Input file substreams correctly detected');
+                videoStreamMeta = meta.input.stream[0][0];
+                audioStreamMeta = meta.input.stream[0][1];
+                t.strictEqual(videoStreamMeta.type, 'video', 'Input video stream correctly detected');
+                t.strictEqual(audioStreamMeta.type, 'audio', 'Input audio stream correctly detected');
+                // video
+                t.strictEqual(videoStreamMeta.codec,         'h264',    'Input video stream codec is correct');
+                t.strictEqual(videoStreamMeta.format,        'yuv420p', 'Input video stream format is correct');
+                t.strictEqual(videoStreamMeta.resolution[0], 320,       'Input video stream width is correct');
+                t.strictEqual(videoStreamMeta.resolution[1], 240,       'Input video stream height is correct');
+                t.strictEqual(videoStreamMeta.bitrate,       202,       'Input video stream bitrate is correct');
+                t.strictEqual(videoStreamMeta.fps,           29.92,     'Input video stream fps is correct');
+                // audio
+                t.strictEqual(audioStreamMeta.codec,         'aac',     'Input audio stream codec is correct');
+                t.strictEqual(audioStreamMeta.samplerate,    22050,     'Input audio stream samplerate is correct');
+                t.strictEqual(audioStreamMeta.channels,      2,         'Input audio stream channels are correct');
+                t.strictEqual(audioStreamMeta.bitrate,       63,        'Input audio stream bitrate is correct');
+
+                // Output meta data
+                t.strictEqual(meta.output.stream.length, 1, 'Output file streams correctly detected')
+                t.strictEqual(meta.output.stream[0].length, 2, 'Output file substreams correctly detected');
+                videoStreamMeta = meta.output.stream[0][0];
+                audioStreamMeta = meta.output.stream[0][1];
+                t.strictEqual(videoStreamMeta.type, 'video', 'Output video stream correctly detected');
+                t.strictEqual(audioStreamMeta.type, 'audio', 'Output audio stream correctly detected');
+                // video
+                t.strictEqual(videoStreamMeta.codec,         'libvpx',  'Output video stream codec is correct');
+                t.strictEqual(videoStreamMeta.format,        'yuv420p', 'Output video stream format is correct');
+                t.strictEqual(videoStreamMeta.resolution[0], 320,       'Output video stream width is correct');
+                t.strictEqual(videoStreamMeta.resolution[1], 240,       'Output video stream height is correct');
+                t.strictEqual(videoStreamMeta.bitrate,       200,       'Output video stream bitrate is correct');
+                // audio
+                t.strictEqual(audioStreamMeta.codec,         'libvorbis','Output audio stream codec is correct');
+                t.strictEqual(audioStreamMeta.samplerate,    22050,      'Output audio stream samplerate is correct');
+                t.strictEqual(audioStreamMeta.channels,      2,          'Output audio stream channels are correct');
 
                 t.done();
             });


### PR DESCRIPTION
Metadata is being parsed on a per stream basis. This actually removes the `meta` event and instead provides the metadata as third parameter to the `exit` event.

The resulting metadata(ie. pokemon_card.flv -> pokemon_card.webm) object looks like this:

```javascript
{
    input: {
        duration: 32056,
        start: 0,
        bitrate: null,
        stream: [
            [
                {
                    type: "video",
                    codec: "h264",
                    format: "yuv420p",
                    resolution: [ 320, 240 ],
                    bitrate: 202,
                    fps: 29.92
                },{
                    type: "audio",
                    codec: "aac",
                    samplerate: 22050,
                    channels: 2,
                    encoding: "fltp",
                    bitrate: 63
                }
            ]
        ]
    },
    output: {
        stream: [
            [
                {
                    type: "video",
                    codec: "libvpx",
                    format: "yuv420p",
                    resolution: [ 320, 240 ],
                    bitrate: 200
                },{
                    type: "audio",
                    codec: "libvorbis",
                    samplerate: 22050,
                    channels: 2,
                    encoding: "fltp",
                    bitrate: null
                }
            ]
        ]
    }
}
```