### PR TITLE
Make avconv executable parametric

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,17 @@ Whereas errors from the stream are rarely filled (`error` event). They happen on
 
 ## API
 
-### stream = avconv(params)
+### stream = avconv(params, [command = 'avconv'])
 
 Avconv spawns a new avconv process with any given parameters. It does not validate the parameters nor mess with the results. That's all up to you. You would see avconv complaining about bad parameters in the `data` event anyway. So:
 
-__one argument__
+__one mandatory argument__
 
 * params - any array list with string arguments as values (see examples)
+
+__one optional argument__
+
+* command - the path to the avconv executable (for example to a static binary). Defaults to 'avconv'.
 
 __one return value__
 

--- a/avconv.js
+++ b/avconv.js
@@ -137,13 +137,14 @@ function parseMetaData(output) {
     return meta;
 }
 
-module.exports = function avconv(params) {
+module.exports = function avconv(params, command) {
     var stream = new AvStream(),
+        command = command || 'avconv',
         // todo: use a queue to deal with the spawn EMFILE exception
         // see http://www.runtime-era.com/2012/10/quick-and-dirty-nodejs-exec-limit-queue.html
         // currently I have added a dirty workaround on the server by increasing
         // the file max descriptor with 'sudo sysctl -w fs.file-max=100000'
-        avconv = spawn('avconv', params);
+        avconv = spawn(command, params);
 
     // General avconv output is always written into stderr
     if (avconv.stderr) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "video encoding"
     ],
     "devDependencies": {
+        "ffmpeg-static": "^2.0.0",
         "nodeunit": "0.9.1"
     },
     "dependencies": {

--- a/tests/basics.js
+++ b/tests/basics.js
@@ -1,8 +1,9 @@
 "use strict";
 
-var testCase  = require('nodeunit').testCase,
-    path      = require('path'),
-    fs        = require('fs'),
+var testCase   = require('nodeunit').testCase,
+    path       = require('path'),
+    fs         = require('fs'),
+    ffmpegPath = require('ffmpeg-static').path,
     avconv,
     AvStream;
 
@@ -292,5 +293,20 @@ module.exports = testCase({
                 t.done();
             });
         }
-    })
+    }),
+    'TC 4: parametric avconv executable': testCase({
+        'loading help (--help) from custom avconv': function(t) {
+            t.expect(3);
+
+            var stream = avconv(['--help'], ffmpegPath);
+
+            read(stream, function(exitCode, signal, output, err) {
+
+                t.strictEqual(exitCode,   0, 'avconv returned help');
+                t.notEqual(output.length, 0, 'stdout contains help');
+                t.strictEqual(err.length, 0, 'stderr is still empty');
+                t.done();
+            });
+        }
+    }),
 });


### PR DESCRIPTION
I wanted to use a static executable instead of requiring the system to have an avconv installed. This allows for combining this npm package with e.g. the ffmpeg-static npm package.